### PR TITLE
Fix PHPStan level 10 errors

### DIFF
--- a/src/CurlHandleReuseLaravelOctaneServiceProvider.php
+++ b/src/CurlHandleReuseLaravelOctaneServiceProvider.php
@@ -11,7 +11,7 @@ class CurlHandleReuseLaravelOctaneServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/curl-handle-reuse-laravel-octane.php', 'curl-handle-reuse-laravel-octane');
         $this->app->instance(ReusedCurlHandle::class, new ReusedCurlHandle(
-            config('curl-handle-reuse-laravel-octane.max_handles'),
+            config()->integer('curl-handle-reuse-laravel-octane.max_handles'),
         ));
         $this->app->bind(Factory::class, ReusedCurlHandleFactory::class);
     }

--- a/src/ReusedCurlHandle.php
+++ b/src/ReusedCurlHandle.php
@@ -30,7 +30,9 @@ class ReusedCurlHandle
     {
         $handler = null;
 
-        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.21.2') >= 0) {
+        $curlVersion = \function_exists('curl_version') ? curl_version() : false;
+
+        if (\defined('CURLOPT_CUSTOMREQUEST') && is_array($curlVersion) && is_string($curlVersion['version']) && version_compare($curlVersion['version'], '7.21.2') >= 0) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(['handle_factory' => new CurlFactory($maxHandles)]), new CurlHandler(['handle_factory' => new CurlFactory($maxHandles)]));
             } elseif (\function_exists('curl_exec')) {


### PR DESCRIPTION
Fixes 3 PHPStan errors at level 10:

- **ServiceProvider**: Use `config()->integer()` instead of passing `mixed` to `int` parameter
- **ReusedCurlHandle**: Extract `curl_version()` result and narrow types with `is_array()` + `is_string()` checks before passing to `version_compare()`