### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "minimum-stability": "stable",
     "require": {
         "php": "^8.2",
-        "illuminate/http": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "ext-curl": "*"
     },
     "extra": {

--- a/src/CurlHandleReuseLaravelOctaneServiceProvider.php
+++ b/src/CurlHandleReuseLaravelOctaneServiceProvider.php
@@ -11,7 +11,7 @@ class CurlHandleReuseLaravelOctaneServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/curl-handle-reuse-laravel-octane.php', 'curl-handle-reuse-laravel-octane');
         $this->app->instance(ReusedCurlHandle::class, new ReusedCurlHandle(
-            config('curl-handle-reuse-laravel-octane.max_handles'),
+            config()->integer('curl-handle-reuse-laravel-octane.max_handles'),
         ));
         $this->app->bind(Factory::class, ReusedCurlHandleFactory::class);
     }

--- a/src/ReusedCurlHandle.php
+++ b/src/ReusedCurlHandle.php
@@ -30,7 +30,9 @@ class ReusedCurlHandle
     {
         $handler = null;
 
-        if (\defined('CURLOPT_CUSTOMREQUEST') && \function_exists('curl_version') && version_compare(curl_version()['version'], '7.21.2') >= 0) {
+        $curlVersion = \function_exists('curl_version') ? curl_version() : false;
+
+        if (\defined('CURLOPT_CUSTOMREQUEST') && is_array($curlVersion) && is_string($curlVersion['version']) && version_compare($curlVersion['version'], '7.21.2') >= 0) {
             if (\function_exists('curl_multi_exec') && \function_exists('curl_exec')) {
                 $handler = Proxy::wrapSync(new CurlMultiHandler(['handle_factory' => new CurlFactory($maxHandles)]), new CurlHandler(['handle_factory' => new CurlFactory($maxHandles)]));
             } elseif (\function_exists('curl_exec')) {


### PR DESCRIPTION
Adds `^13.0` to `illuminate/http` and `illuminate/support` version constraints.

Depends on #3 (PHPStan fixes). Sent as a separate PR to keep concerns isolated.